### PR TITLE
update exploratory per ietf109 hackathon 11/12

### DIFF
--- a/strawman-examples/Bluetooth-Mesh/sdfdata-sensorstate.sdf.json
+++ b/strawman-examples/Bluetooth-Mesh/sdfdata-sensorstate.sdf.json
@@ -6,7 +6,7 @@
     "license": "https://github.com/one-data-model/oneDM/blob/master/LICENSE"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultnamespace": "ex", 
 

--- a/strawman-examples/Bluetooth-Mesh/sdfobject-genericdefaulttransitiontime.sdf.json
+++ b/strawman-examples/Bluetooth-Mesh/sdfobject-genericdefaulttransitiontime.sdf.json
@@ -6,7 +6,7 @@
     "license": "https://github.com/one-data-model/oneDM/blob/master/LICENSE"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   

--- a/strawman-examples/Bluetooth-Mesh/sdfobject-genericonoff.sdf.json
+++ b/strawman-examples/Bluetooth-Mesh/sdfobject-genericonoff.sdf.json
@@ -6,7 +6,7 @@
     "license": "https://github.com/one-data-model/oneDM/blob/master/LICENSE"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   
@@ -20,7 +20,7 @@
       "sdfAction": {
         "OnOffGet": {
           "description": "Get the status of the On/Off server",
-          "sdfData": {
+          "sdfOutputData": {
             "type": "object",
             "properties": {
               "PresentOnOff": {
@@ -56,13 +56,13 @@
       "sdfData": {
         "GenericOnOffData": {
           "description": "the on/off state property, use a mapping file for encoded values",
-          "enum": [
-            "Off", 
-            "On"
-          ]
+          "sdfEnum": {
+            "Off": {}, 
+            "On": {}
+          }
         },
         "TransitionTimeData": {
-          "sdfRef": "ex:/sdfObject/GenericDefaultTransitionTime/sdfData/TransitionTimeData"
+          "sdfRef": "ex:#/sdfObject/GenericDefaultTransitionTime/sdfData/TransitionTimeData"
         },
         "DelayData": {
           "description": "delay in increments of 5mS",

--- a/strawman-examples/CAP/sdfdata-ovenModeData.sdf.json
+++ b/strawman-examples/CAP/sdfdata-ovenModeData.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
 

--- a/strawman-examples/CAP/sdfobject-motion-sensor.sdf.json
+++ b/strawman-examples/CAP/sdfobject-motion-sensor.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   "sdfObject": {

--- a/strawman-examples/CAP/sdfobject-oven-mode.sdf.json
+++ b/strawman-examples/CAP/sdfobject-oven-mode.sdf.json
@@ -6,8 +6,8 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#",
-    "pg": "https://onedm.org/playground/#"
+    "ex": "https://onedm.org/exploratory/",
+    "pg": "https://onedm.org/playground/"
   }, 
   "defaultNamespace": "ex", 
 
@@ -21,12 +21,12 @@
       ],
       "sdfProperty": {
         "ovenMode": {
-            "sdfRef": "pg:sdfData/OvenMode"
+            "sdfRef": "ex:#/sdfData/OvenMode"
         },
         "supportedOvenModes": {
           "type": "array",
           "items": {
-            "sdfRef": "pg:sdfData/OvenMode"
+            "sdfRef": "ex:#/sdfData/OvenMode"
           }
         }
       }, 
@@ -39,7 +39,7 @@
             "type": "object",
               "properties": {
               "ovenMode": {
-                "sdfRef": "pg:sdfData/OvenMode"
+                "sdfRef": "ex:#/sdfData/OvenMode"
               }
             }
           }

--- a/strawman-examples/CAP/sdfobject-oven-operating-state.sdf.json
+++ b/strawman-examples/CAP/sdfobject-oven-operating-state.sdf.json
@@ -6,8 +6,8 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#",
-    "pg": "https://onedm.org/playground/#"
+    "ex": "https://onedm.org/exploratory/",
+    "pg": "https://onedm.org/playground/"
   }, 
   "defaultNamespace": "ex", 
 
@@ -21,35 +21,42 @@
       ],
       "sdfProperty": {
         "machineState": {
-          "type": "string", 
-          "enum": [ "ready", "running", "paused" ]
+          "sdfEnum": {
+            "ready": {}, 
+            "running": {}, 
+            "paused": {}
+          }
         },
         "supportedMachineStates": {
           "type": "array",
           "items": {
-            "enum": [ "ready", "running", "paused" ]
+            "sdfEnum": {
+              "ready": {}, 
+              "running": {}, 
+              "paused": {}
+            }
           }
         },
         "ovenJobState": {
           "type": "string",
-          "enum": [
-            "cleaning",
-            "cooking",
-            "cooling",
-            "draining",
-            "preheat",
-            "ready",
-            "rinsing"
-          ]
+          "sdfEnum": {
+            "cleaning": {},
+            "cooking": {},
+            "cooling": {},
+            "draining": {},
+            "preheat": {},
+            "ready": {},
+            "rinsing": {}
+          }
         },
         "completionTime": {
-          "sdfRef": "pg:/sdfData/iso8601date"
+          "sdfRef": "ex:#/sdfData/iso8601date"
         },
         "operationTime": {
-          "sdfRef": "pg:/sdfData/PositiveInteger"
+          "sdfRef": "ex:#/sdfData/PositiveInteger"
         },
         "progress": {
-          "sdfRef": "pg:/sdfData/IntegerPercent"
+          "sdfRef": "ex:#/sdfData/IntegerPercent"
         }
       }, 
       "sdfAction": {
@@ -61,7 +68,7 @@
             "type": "object",
             "properties": {
               "ovenMode": {
-                "sdfRef": "ex:/sdfData/OvenMode"
+                "sdfRef": "ex:#/sdfData/OvenMode"
               }
             }
           }
@@ -72,12 +79,17 @@
             "type": "object",
             "properties": {
               "ovenMode": {
-                "sdfRef": "ex:/sdfData/OvenMode"
+                "sdfRef": "ex:#/sdfData/OvenMode"
               }
             }
           }
         }
       }
     }
+  },
+  "sdfData": {
+    "iso8601date": {"description": "tbd"},
+    "PositiveInteger": {"description": "tbd"},
+    "IntegerPercent": {"description": "tbd"}
   }
 }

--- a/strawman-examples/IPSO/sdfaction-generic.sdf.json
+++ b/strawman-examples/IPSO/sdfaction-generic.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
 

--- a/strawman-examples/IPSO/sdfobject-genericSensor.sdf.json
+++ b/strawman-examples/IPSO/sdfobject-genericSensor.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   "sdfObject": {
@@ -17,33 +17,33 @@
       ],
       "sdfProperty": {
         "sensorValue": {
-          "sdfRef": "ex:/sdfProperty/sensorValue"
+          "sdfRef": "ex:#/sdfProperty/sensorValue"
         }, 
         "minimumMeasuredValue": {
-          "sdfRef": "ex:/sdfProperty/minimumMeasuredValue"
+          "sdfRef": "ex:#/sdfProperty/minimumMeasuredValue"
         }, 
         "maximumMeasuredValue": {
-          "sdfRef": "ex:/sdfProperty/maximumMeasuredValue"
+          "sdfRef": "ex:#/sdfProperty/maximumMeasuredValue"
         }, 
         "minimumRangeValue": {
-          "sdfRef": "ex:/sdfProperty/minimumRangeValue"
+          "sdfRef": "ex:#/sdfProperty/minimumRangeValue"
         }, 
         "maximumRangeValue": {
-          "sdfRef": "ex:/sdfProperty/maximumRangeValue"
+          "sdfRef": "ex:#/sdfProperty/maximumRangeValue"
         }, 
         "applicationType": {
-          "sdfRef": "ex:/sdfProperty/applicationType"
+          "sdfRef": "ex:#/sdfProperty/applicationType"
         }, 
         "sensorType": {
-          "sdfRef": "ex:/sdfProperty/sensorType"
+          "sdfRef": "ex:#/sdfProperty/sensorType"
         }, 
         "units": {
-          "sdfRef": "ex:/sdfProperty/units"
+          "sdfRef": "ex:#/sdfProperty/units"
         }
       }, 
       "sdfAction": {
         "resetMinMax": {
-          "sdfRef": "ex:/sdfAction/resetMinMax"
+          "sdfRef": "ex:#/sdfAction/resetMinMax"
         }
       }
     }

--- a/strawman-examples/IPSO/sdfproperty-generic.sdf.json
+++ b/strawman-examples/IPSO/sdfproperty-generic.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
 

--- a/strawman-examples/IPSO/sdfthing-ipsoVacGauge.sdf.json
+++ b/strawman-examples/IPSO/sdfthing-ipsoVacGauge.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   "sdfProduct": {
@@ -18,7 +18,7 @@
       "sdfObject": {
         "HighRangeSensor": {
           "description": "Map to Object Instance ID 3300/0",
-          "sdfRef": "ex:/sdfObject/genericSensor", 
+          "sdfRef": "ex:#/sdfObject/genericSensor", 
           "sdfProperty": {
             "minimumRange": {
               "const": -120000
@@ -39,7 +39,7 @@
         }, 
         "LowRangeSensor": {
           "description": "Map to Object Instance ID 3300/1",
-          "sdfRef": "ex:/sdfObject/genericSensor", 
+          "sdfRef": "ex:#/sdfObject/genericSensor", 
           "sdfProperty": {
             "minimumRange": {
               "const": 0

--- a/strawman-examples/OCF/sdfobject-mediacore.sdf.json
+++ b/strawman-examples/OCF/sdfobject-mediacore.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultnamespace": "ex", 
 

--- a/strawman-examples/OCF/sdfthing-ocf-airflowcontrol.sdf.json
+++ b/strawman-examples/OCF/sdfthing-ocf-airflowcontrol.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
 
@@ -47,11 +47,10 @@
         "automode" : {
           "label": "automode",
           "description": "The status of the automode feature, if on speed is set by the Device.",
-          "type": "string",
-          "enum": [
-            "On",
-            "Off"
-          ]
+          "sdfEnum": {
+            "On": {},
+            "Off": {}
+          }
         },
         "supporteddirections" : {
           "description": "The array of possible direction settings for this instance of the Resource Type.",

--- a/strawman-examples/ZCL/sdfobject-level-v7.sdf.json
+++ b/strawman-examples/ZCL/sdfobject-level-v7.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   "sdfObject": {
@@ -117,12 +117,9 @@
       "sdfAction": {
         "MoveToLevel": {
           "label": "MoveToLevel", 
-          "sdfRequired": [
-            "#/sdfObject/Level/sdfAction/MoveToLevel/sdfInputData/properties/Level", 
-            "#/sdfObject/Level/sdfAction/MoveToLevel/sdfInputData/properties/TransitionTime"
-          ],
           "sdfInputData": {
             "type": "object",
+            "required": ["Level", "TransitionTime"],
             "properties": {
               "Level": {
                 "label": "Level", 
@@ -145,12 +142,9 @@
         }, 
         "Move": {
           "label": "Move", 
-          "sdfRequired": [
-            "#/sdfObject/Level/sdfAction/Move/sdfInputData/properties/MoveMode", 
-            "#/sdfObject/Level/sdfAction/Move/sdfInputData/properties/Rate"
-          ],
           "sdfInputData": {
             "type": "object",
+            "required": ["MoveMode", "Rate"],
             "properties": {
               "MoveMode": {
                 "label": "MoveMode", 
@@ -175,13 +169,9 @@
         }, 
         "Step": {
           "label": "Step", 
-          "sdfRequired": [
-            "#/sdfObject/Level/sdfAction/Step/sdfInputData/properties/StepMode",
-            "#/sdfObject/Level/sdfAction/Step/sdfInputData/properties/StepSize",
-            "#/sdfObject/Level/sdfAction/Step/sdfInputData/properties/TransitionTime"
-          ],
           "sdfInputData": {
             "type": "object",
+            "required": ["StepMode", "StepSize", "TransitionTime"],
             "properties": {
               "StepMode": {
                 "label": "Step mode", 

--- a/strawman-examples/ZCL/sdfobject-onoff-v7.sdf.json
+++ b/strawman-examples/ZCL/sdfobject-onoff-v7.sdf.json
@@ -6,7 +6,7 @@
     "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   "sdfObject": {
@@ -86,13 +86,15 @@
         }, 
         "OnWithTimedOff": {
           "label": "OnWithTimedOff", 
-          "type": "object",
-          "properties": {
-            "OnOffControl": {
-              "type": "object",
-              "properties" : {
-                "AcceptOnlyWhenOn": {
-                  "type": "boolean"
+          "sdfInputData": {
+            "type": "object",
+            "properties": {
+              "OnOffControl": {
+                "type": "object",
+                "properties" : {
+                  "AcceptOnlyWhenOn": {
+                    "type": "boolean"
+                  }
                 }
               }
             }

--- a/strawman-examples/ZCL/zcl.smf.json
+++ b/strawman-examples/ZCL/zcl.smf.json
@@ -6,34 +6,34 @@
   "license": "http://example.com/license"
   }, 
   "namespace": {
-    "ex": "https://onedm.org/exploratory/#"
+    "ex": "https://onedm.org/exploratory/"
   }, 
   "defaultNamespace": "ex", 
   
   "sdfMap": {
-    "ex:/sdfObject/Level" : {
+    "ex:#/sdfObject/Level" : {
       "id": 8
     },
-    "ex:/sdfObject/Level/sdfProperty/CurrentLevel" : {
+    "ex:#/sdfObject/Level/sdfProperty/CurrentLevel" : {
       "id": 0
     },
-    "ex:/sdfObject/Level/sdfProperty/RemainingTime" : {
+    "ex:#/sdfObject/Level/sdfProperty/RemainingTime" : {
       "id": 1
     },
-    "ex:/sdfObject/Level/sdfProperty/OnOffTransitionTime" : {
+    "ex:#/sdfObject/Level/sdfProperty/OnOffTransitionTime" : {
       "id": 16
     },
-    "ex:/sdfObject/Level/sdfAction/MoveToLevel" : {
+    "ex:#/sdfObject/Level/sdfAction/MoveToLevel" : {
       "id": 0
     },
-    "ex:/sdfObject/Level/sdfAction/Move" : {
+    "ex:#/sdfObject/Level/sdfAction/Move" : {
       "id": 1
     },
-    "ex:/sdfObject/Level/sdfData/MoveStepMode/sdfEnum/Up" : {
+    "ex:#/sdfObject/Level/sdfData/MoveStepMode/sdfEnum/Up" : {
       "type": "number",
       "const": 0
     },
-    "ex:/sdfObject/Level/sdfData/MoveStepMode/sdfEnum/Down" : {
+    "ex:#/sdfObject/Level/sdfData/MoveStepMode/sdfEnum/Down" : {
       "type": "number",
       "const": 1
     }


### PR DESCRIPTION
Put the fragment "#" in the cross-references, e.g. ex:#/sdfData... and remove from the namespace declaration

convert all enums to sdfEnum to illustrate the simple conversion to string enum

use json-schema "required" for sdfInputData and sdfOutputData